### PR TITLE
biblio change name

### DIFF
--- a/server/server/data_loader/biblio.py
+++ b/server/server/data_loader/biblio.py
@@ -6,7 +6,7 @@ def load_biblios(db, additional_info_dir: Path):
     print('Loading biblio data')
 
     biblio_collection = db['biblios']
-    with open(f'{additional_info_dir}/biblio_volpage.json') as f:
+    with open(f'{additional_info_dir}/biblio.json') as f:
         data = json.load(f)
 
     biblio_collection.import_bulk(data)


### PR DESCRIPTION
Just changing the filename from biblio_volpage.json to biblio.json. The file does not contain volpage info.