### PR TITLE
Import bulk refactor

### DIFF
--- a/server/server/common/models.py
+++ b/server/server/common/models.py
@@ -58,7 +58,7 @@ class ModelList(list):
         db = get_db()
         collection = db.collection(collection)
 
-        return collection.import_bulk([m.document for m in self], halt_on_error=True)
+        return collection.import_bulk_safe([m.document for m in self])
 
 
 class Language(Model):

--- a/server/server/common/models.py
+++ b/server/server/common/models.py
@@ -58,7 +58,7 @@ class ModelList(list):
         db = get_db()
         collection = db.collection(collection)
 
-        return collection.import_bulk([m.document for m in self])
+        return collection.import_bulk([m.document for m in self], halt_on_error=True)
 
 
 class Language(Model):

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -206,8 +206,7 @@ def process_category_files(category_files, db, edges, mapping):
                 del entry['grouping']
 
             category_docs.append(entry)
-        collection.truncate()
-        collection.import_bulk(category_docs, halt_on_error=True)
+        collection.import_bulk(category_docs, overwrite=True, halt_on_error=True)
 
 
 def perform_update_queries(db):
@@ -245,12 +244,9 @@ def add_root_docs_and_edges(change_tracker, db, structure_dir):
                     entry['grouping'] = 'other'
 
         # make documents
-        db['root'].truncate()
-        db['root'].import_bulk(docs, halt_on_error=True)
-        db['root_names'].truncate()
-        db['root_names'].import_bulk(name_docs, halt_on_error=True)
-        db['root_edges'].truncate()
-        db['root_edges'].import_bulk(edges, halt_on_error=True)
+        db['root'].import_bulk(docs, overwrite=True, halt_on_error=True)
+        db['root_names'].import_bulk(name_docs, overwrite=True, halt_on_error=True)
+        db['root_edges'].import_bulk(edges, overwrite=True, halt_on_error=True)
 
         perform_update_queries(db)
 
@@ -363,8 +359,7 @@ def generate_relationship_edges(change_tracker, relationship_dir, additional_inf
                             'resembling': any(x.startswith('~') for x in [first_uid, from_uid]),
                             'remark': remark
                         })
-    db['relationship'].truncate()
-    db['relationship'].import_bulk(ll_edges, from_prefix='root/', to_prefix='root/', halt_on_error=True)
+    db['relationship'].import_bulk(ll_edges, from_prefix='root/', to_prefix='root/', overwrite=True, halt_on_error=True)
 
 
 def load_html_texts(change_tracker, data_dir, db, html_dir, additional_info_dir):
@@ -406,8 +401,7 @@ def load_json_file(db, change_tracker, json_file):
     if 'uid' in data[0]:
         for d in data:
             d['_key'] = d['uid']
-        db[collection_name].truncate()
-        db[collection_name].import_bulk(data, halt_on_error=True)
+        db[collection_name].import_bulk(data, overwrite=True, halt_on_error=True)
 
 
 def process_blurbs(db, additional_info_dir):
@@ -420,23 +414,20 @@ def process_blurbs(db, additional_info_dir):
     docs = [{'uid': uid, 'lang': lang, 'blurb': blurb}
             for lang, groups in blurb_info.items() for suttas in groups.values() for uid, blurb in
             tqdm(suttas.items())]
-
-    db.collection(collection_name).truncate()
-    db.collection('blurbs').import_bulk(docs, halt_on_error=True)
+    
+    db.collection('blurbs').import_bulk(docs, overwrite=True, halt_on_error=True)
 
 
 def process_difficulty(db, additional_info_dir):
     print('Loading difficulties')
     difficulty_file = additional_info_dir / 'difficulties.json'
-    collection_name = 'difficulties'
 
     difficulty_info = json_load(difficulty_file)
 
     docs = [{'uid': uid, 'difficulty': lvl}
             for x in difficulty_info.values() for uid, lvl in tqdm(x.items())]
 
-    db.collection(collection_name).truncate()
-    db.collection('difficulties').import_bulk(docs, halt_on_error=True)
+    db.collection('difficulties').import_bulk(docs, overwrite=True, halt_on_error=True)
 
 
 def run(no_pull=False):

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -206,7 +206,7 @@ def process_category_files(category_files, db, edges, mapping):
                 del entry['grouping']
 
             category_docs.append(entry)
-        collection.import_bulk(category_docs, overwrite=True, halt_on_error=True)
+        collection.import_bulk_safe(category_docs, overwrite=True)
 
 
 def perform_update_queries(db):
@@ -244,9 +244,9 @@ def add_root_docs_and_edges(change_tracker, db, structure_dir):
                     entry['grouping'] = 'other'
 
         # make documents
-        db['root'].import_bulk(docs, overwrite=True, halt_on_error=True)
-        db['root_names'].import_bulk(name_docs, overwrite=True, halt_on_error=True)
-        db['root_edges'].import_bulk(edges, overwrite=True, halt_on_error=True)
+        db['root'].import_bulk_safe(docs, overwrite=True)
+        db['root_names'].import_bulk_safe(name_docs, overwrite=True)
+        db['root_edges'].import_bulk_safe(edges, overwrite=True)
 
         perform_update_queries(db)
 
@@ -359,7 +359,7 @@ def generate_relationship_edges(change_tracker, relationship_dir, additional_inf
                             'resembling': any(x.startswith('~') for x in [first_uid, from_uid]),
                             'remark': remark
                         })
-    db['relationship'].import_bulk(ll_edges, from_prefix='root/', to_prefix='root/', overwrite=True, halt_on_error=True)
+    db['relationship'].import_bulk_safe(ll_edges, from_prefix='root/', to_prefix='root/', overwrite=True)
 
 
 def load_html_texts(change_tracker, data_dir, db, html_dir, additional_info_dir):
@@ -401,7 +401,7 @@ def load_json_file(db, change_tracker, json_file):
     if 'uid' in data[0]:
         for d in data:
             d['_key'] = d['uid']
-        db[collection_name].import_bulk(data, overwrite=True, halt_on_error=True)
+        db[collection_name].import_bulk_safe(data, overwrite=True)
 
 
 def process_blurbs(db, additional_info_dir):
@@ -415,7 +415,7 @@ def process_blurbs(db, additional_info_dir):
             for lang, groups in blurb_info.items() for suttas in groups.values() for uid, blurb in
             tqdm(suttas.items())]
     
-    db.collection('blurbs').import_bulk(docs, overwrite=True, halt_on_error=True)
+    db.collection('blurbs').import_bulk_safe(docs, overwrite=True)
 
 
 def process_difficulty(db, additional_info_dir):
@@ -427,7 +427,7 @@ def process_difficulty(db, additional_info_dir):
     docs = [{'uid': uid, 'difficulty': lvl}
             for x in difficulty_info.values() for uid, lvl in tqdm(x.items())]
 
-    db.collection('difficulties').import_bulk(docs, overwrite=True, halt_on_error=True)
+    db.collection('difficulties').import_bulk_safe(docs, overwrite=True)
 
 
 def run(no_pull=False):

--- a/server/server/data_loader/arangoload.py
+++ b/server/server/data_loader/arangoload.py
@@ -207,7 +207,7 @@ def process_category_files(category_files, db, edges, mapping):
 
             category_docs.append(entry)
         collection.truncate()
-        collection.import_bulk(category_docs)
+        collection.import_bulk(category_docs, halt_on_error=True)
 
 
 def perform_update_queries(db):
@@ -246,11 +246,11 @@ def add_root_docs_and_edges(change_tracker, db, structure_dir):
 
         # make documents
         db['root'].truncate()
-        db['root'].import_bulk(docs)
+        db['root'].import_bulk(docs, halt_on_error=True)
         db['root_names'].truncate()
-        db['root_names'].import_bulk(name_docs)
+        db['root_names'].import_bulk(name_docs, halt_on_error=True)
         db['root_edges'].truncate()
-        db['root_edges'].import_bulk(edges)
+        db['root_edges'].import_bulk(edges, halt_on_error=True)
 
         perform_update_queries(db)
 
@@ -364,7 +364,7 @@ def generate_relationship_edges(change_tracker, relationship_dir, additional_inf
                             'remark': remark
                         })
     db['relationship'].truncate()
-    db['relationship'].import_bulk(ll_edges, from_prefix='root/', to_prefix='root/')
+    db['relationship'].import_bulk(ll_edges, from_prefix='root/', to_prefix='root/', halt_on_error=True)
 
 
 def load_html_texts(change_tracker, data_dir, db, html_dir, additional_info_dir):
@@ -407,7 +407,7 @@ def load_json_file(db, change_tracker, json_file):
         for d in data:
             d['_key'] = d['uid']
         db[collection_name].truncate()
-        db[collection_name].import_bulk(data)
+        db[collection_name].import_bulk(data, halt_on_error=True)
 
 
 def process_blurbs(db, additional_info_dir):
@@ -422,7 +422,7 @@ def process_blurbs(db, additional_info_dir):
             tqdm(suttas.items())]
 
     db.collection(collection_name).truncate()
-    db.collection('blurbs').import_bulk(docs)
+    db.collection('blurbs').import_bulk(docs, halt_on_error=True)
 
 
 def process_difficulty(db, additional_info_dir):
@@ -436,7 +436,7 @@ def process_difficulty(db, additional_info_dir):
             for x in difficulty_info.values() for uid, lvl in tqdm(x.items())]
 
     db.collection(collection_name).truncate()
-    db.collection('difficulties').import_bulk(docs)
+    db.collection('difficulties').import_bulk(docs, halt_on_error=True)
 
 
 def run(no_pull=False):

--- a/server/server/data_loader/biblio.py
+++ b/server/server/data_loader/biblio.py
@@ -7,4 +7,4 @@ def load_biblios(db, additional_info_dir: Path):
     biblio_collection = db['biblios']
     data = json_load(additional_info_dir / 'biblio.json')
 
-    biblio_collection.import_bulk(data)
+    biblio_collection.import_bulk(data, halt_on_error=True)

--- a/server/server/data_loader/biblio.py
+++ b/server/server/data_loader/biblio.py
@@ -7,4 +7,4 @@ def load_biblios(db, additional_info_dir: Path):
     biblio_collection = db['biblios']
     data = json_load(additional_info_dir / 'biblio.json')
 
-    biblio_collection.import_bulk(data, halt_on_error=True)
+    biblio_collection.import_bulk_safe(data)

--- a/server/server/data_loader/change_tracker.py
+++ b/server/server/data_loader/change_tracker.py
@@ -78,7 +78,7 @@ class ChangeTracker:
             [{'path': k, 'mtime': v, '_key': k.replace('/', '_')} for k, v in
              self.changed_or_new.items()], on_duplicate="replace")
         self.db['function_hashes'].truncate()
-        self.db['function_hashes'].import_bulk([{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()])
+        self.db['function_hashes'].import_bulk([{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()], halt_on_error=True)
 
 def function_source(function):
     return ''.join(inspect.getsourcelines(function)[0])

--- a/server/server/data_loader/change_tracker.py
+++ b/server/server/data_loader/change_tracker.py
@@ -74,12 +74,12 @@ class ChangeTracker:
                                 FILTER entry.path IN @to_remove 
                                 REMOVE entry IN mtimes''', bind_vars={'to_remove': list(self.deleted)})
 
-        self.db['mtimes'].import_bulk(
+        self.db['mtimes'].import_bulk_safe(
             [{'path': k, 'mtime': v, '_key': k.replace('/', '_')} for k, v in
-             self.changed_or_new.items()], on_duplicate="replace", halt_on_error=True)
+             self.changed_or_new.items()], on_duplicate="replace")
         self.db['function_hashes'].truncate()
         docs = [{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()]
-        self.db['function_hashes'].import_bulk(docs, overwrite=True, halt_on_error=True)
+        self.db['function_hashes'].import_bulk_safe(docs, overwrite=True)
 
 def function_source(function):
     return ''.join(inspect.getsourcelines(function)[0])

--- a/server/server/data_loader/change_tracker.py
+++ b/server/server/data_loader/change_tracker.py
@@ -76,9 +76,10 @@ class ChangeTracker:
 
         self.db['mtimes'].import_bulk(
             [{'path': k, 'mtime': v, '_key': k.replace('/', '_')} for k, v in
-             self.changed_or_new.items()], on_duplicate="replace")
+             self.changed_or_new.items()], on_duplicate="replace", halt_on_error=True)
         self.db['function_hashes'].truncate()
-        self.db['function_hashes'].import_bulk([{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()], halt_on_error=True)
+        docs = [{'_key': k, 'hash': v} for k, v in self.new_function_hashes.items()]
+        self.db['function_hashes'].import_bulk(docs, overwrite=True, halt_on_error=True)
 
 def function_source(function):
     return ''.join(inspect.getsourcelines(function)[0])

--- a/server/server/data_loader/currencies.py
+++ b/server/server/data_loader/currencies.py
@@ -17,5 +17,5 @@ def load_currencies(db, additional_info_dir: Path):
             'lang': 'en',
             '_key': f'{entry["symbol"]}_en'
         })
-    currencies_collection.import_bulk(data)
-    currency_names_collection.import_bulk(name_data)
+    currencies_collection.import_bulk(data, halt_on_error=True)
+    currency_names_collection.import_bulk(name_data, halt_on_error=True)

--- a/server/server/data_loader/currencies.py
+++ b/server/server/data_loader/currencies.py
@@ -17,5 +17,5 @@ def load_currencies(db, additional_info_dir: Path):
             'lang': 'en',
             '_key': f'{entry["symbol"]}_en'
         })
-    currencies_collection.import_bulk(data, halt_on_error=True)
-    currency_names_collection.import_bulk(name_data, halt_on_error=True)
+    currencies_collection.import_bulk_safe(data)
+    currency_names_collection.import_bulk_safe(name_data)

--- a/server/server/data_loader/dictionaries.py
+++ b/server/server/data_loader/dictionaries.py
@@ -30,4 +30,4 @@ def load_lookups(db, dictionaries_dir):
             })
         except ValueError:
             print(f'unknown dictionary name format {dictionary.stem}')
-    dictionaries_collection.import_bulk(docs)
+    dictionaries_collection.import_bulk(docs, halt_on_error=True)

--- a/server/server/data_loader/dictionaries.py
+++ b/server/server/data_loader/dictionaries.py
@@ -30,4 +30,4 @@ def load_lookups(db, dictionaries_dir):
             })
         except ValueError:
             print(f'unknown dictionary name format {dictionary.stem}')
-    dictionaries_collection.import_bulk(docs, halt_on_error=True)
+    dictionaries_collection.import_bulk_safe(docs)

--- a/server/server/data_loader/dictionary_full.py
+++ b/server/server/data_loader/dictionary_full.py
@@ -50,4 +50,4 @@ def load_dictionary_full(db, dictionaries_dir, change_tracker):
         doc['similar'] = [t[0] for t in fm.search(doc['word'])]
     
     dictionary_full_collection.truncate()
-    dictionary_full_collection.import_bulk(docs)
+    dictionary_full_collection.import_bulk(docs, halt_on_error=True)

--- a/server/server/data_loader/dictionary_full.py
+++ b/server/server/data_loader/dictionary_full.py
@@ -49,5 +49,4 @@ def load_dictionary_full(db, dictionaries_dir, change_tracker):
         doc['num'] = word_number[doc['word']]
         doc['similar'] = [t[0] for t in fm.search(doc['word'])]
     
-    dictionary_full_collection.truncate()
-    dictionary_full_collection.import_bulk(docs, halt_on_error=True)
+    dictionary_full_collection.import_bulk(docs, overwrite=True, halt_on_error=True)

--- a/server/server/data_loader/dictionary_full.py
+++ b/server/server/data_loader/dictionary_full.py
@@ -49,4 +49,4 @@ def load_dictionary_full(db, dictionaries_dir, change_tracker):
         doc['num'] = word_number[doc['word']]
         doc['similar'] = [t[0] for t in fm.search(doc['word'])]
     
-    dictionary_full_collection.import_bulk(docs, overwrite=True, halt_on_error=True)
+    dictionary_full_collection.import_bulk_safe(docs, overwrite=True)

--- a/server/server/data_loader/divisions.py
+++ b/server/server/data_loader/divisions.py
@@ -20,8 +20,8 @@ def load_divisions(db, structure_dir: Path):
                          for i, entry in enumerate(division_data)]
         text_division_data_objects += division_data
 
-    divisions_collection.import_bulk(division_objects)
-    text_divisions_collection.import_bulk(text_division_data_objects)
+    divisions_collection.import_bulk(division_objects, halt_on_error=True)
+    text_divisions_collection.import_bulk(text_division_data_objects, halt_on_error=True)
 
 
 def get_uid(entry):

--- a/server/server/data_loader/divisions.py
+++ b/server/server/data_loader/divisions.py
@@ -20,8 +20,8 @@ def load_divisions(db, structure_dir: Path):
                          for i, entry in enumerate(division_data)]
         text_division_data_objects += division_data
 
-    divisions_collection.import_bulk(division_objects, halt_on_error=True)
-    text_divisions_collection.import_bulk(text_division_data_objects, halt_on_error=True)
+    divisions_collection.import_bulk_safe(division_objects)
+    text_divisions_collection.import_bulk_safe(text_division_data_objects)
 
 
 def get_uid(entry):

--- a/server/server/data_loader/homepage.py
+++ b/server/server/data_loader/homepage.py
@@ -10,7 +10,7 @@ def load_epigraphs(db, additional_info_dir: Path):
     epigraphs_collection = db['epigraphs']
 
     with epigraphs.open() as f:
-        epigraphs_collection.import_bulk(json.load(f), halt_on_error=True)
+        epigraphs_collection.import_bulk_safe(json.load(f))
 
 
 def load_why_we_read(db, additional_info_dir: Path):
@@ -22,4 +22,4 @@ def load_why_we_read(db, additional_info_dir: Path):
     why_we_read_collection = db['why_we_read']
 
     with why_we_read.open() as f:
-        why_we_read_collection.import_bulk([{'text': x} for x in json.load(f)], halt_on_error=True)
+        why_we_read_collection.import_bulk_safe([{'text': x} for x in json.load(f)])

--- a/server/server/data_loader/homepage.py
+++ b/server/server/data_loader/homepage.py
@@ -10,7 +10,7 @@ def load_epigraphs(db, additional_info_dir: Path):
     epigraphs_collection = db['epigraphs']
 
     with epigraphs.open() as f:
-        epigraphs_collection.import_bulk(json.load(f))
+        epigraphs_collection.import_bulk(json.load(f), halt_on_error=True)
 
 
 def load_why_we_read(db, additional_info_dir: Path):
@@ -22,4 +22,4 @@ def load_why_we_read(db, additional_info_dir: Path):
     why_we_read_collection = db['why_we_read']
 
     with why_we_read.open() as f:
-        why_we_read_collection.import_bulk([{'text': x} for x in json.load(f)])
+        why_we_read_collection.import_bulk([{'text': x} for x in json.load(f)], halt_on_error=True)

--- a/server/server/data_loader/images_files.py
+++ b/server/server/data_loader/images_files.py
@@ -28,7 +28,7 @@ def load_images_links(db):
             })
 
     collection = db['images']
-    collection.import_bulk(entries)
+    collection.import_bulk(entries, halt_on_error=True)
 
 
 def get_data():

--- a/server/server/data_loader/images_files.py
+++ b/server/server/data_loader/images_files.py
@@ -28,7 +28,7 @@ def load_images_links(db):
             })
 
     collection = db['images']
-    collection.import_bulk(entries, halt_on_error=True)
+    collection.import_bulk_safe(entries)
 
 
 def get_data():

--- a/server/server/data_loader/paragraphs.py
+++ b/server/server/data_loader/paragraphs.py
@@ -6,4 +6,4 @@ def load_paragraphs(db, additional_info_dir: Path):
 
     paragraphs_collection = db['paragraphs']
     data = json_load(additional_info_dir / 'paragraphs.json')
-    paragraphs_collection.import_bulk(data)
+    paragraphs_collection.import_bulk(data, halt_on_error=True)

--- a/server/server/data_loader/paragraphs.py
+++ b/server/server/data_loader/paragraphs.py
@@ -6,4 +6,4 @@ def load_paragraphs(db, additional_info_dir: Path):
 
     paragraphs_collection = db['paragraphs']
     data = json_load(additional_info_dir / 'paragraphs.json')
-    paragraphs_collection.import_bulk(data, halt_on_error=True)
+    paragraphs_collection.import_bulk_safe(data)

--- a/server/server/data_loader/po.py
+++ b/server/server/data_loader/po.py
@@ -217,7 +217,7 @@ def load_po_texts(change_tracker, po_dir, db, additional_info_dir):
                     doc['_key'] = f'{doc["lang"]}_{doc["uid"]}_{doc["author"]}'
                     string_docs.append(doc)
             
-            db['po_markup'].import_bulk(markup_docs, on_duplicate='ignore')
-            db['po_strings'].import_bulk(string_docs, on_duplicate='error')
+            db['po_markup'].import_bulk(markup_docs, on_duplicate='ignore', halt_on_error=True)
+            db['po_strings'].import_bulk(string_docs, on_duplicate='error', halt_on_error=True)
                     
             

--- a/server/server/data_loader/po.py
+++ b/server/server/data_loader/po.py
@@ -217,7 +217,7 @@ def load_po_texts(change_tracker, po_dir, db, additional_info_dir):
                     doc['_key'] = f'{doc["lang"]}_{doc["uid"]}_{doc["author"]}'
                     string_docs.append(doc)
             
-            db['po_markup'].import_bulk(markup_docs, on_duplicate='ignore', halt_on_error=True)
-            db['po_strings'].import_bulk(string_docs, on_duplicate='error', halt_on_error=True)
+            db['po_markup'].import_bulk_safe(markup_docs, on_duplicate='ignore')
+            db['po_strings'].import_bulk_safe(string_docs, on_duplicate='error')
                     
             

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -264,7 +264,7 @@ class ArangoTextInfoModel(TextInfoModel):
             self.flush_documents()
 
     def flush_documents(self):
-        self.db['html_text'].import_bulk(self.queue, on_duplicate='replace')
+        self.db['html_text'].import_bulk(self.queue, on_duplicate='replace', halt_on_error=True)
         self.queue.clear()
 
     def update_code_points(self, lang_uid, unicode_points, force=False):

--- a/server/server/data_loader/textdata.py
+++ b/server/server/data_loader/textdata.py
@@ -264,7 +264,7 @@ class ArangoTextInfoModel(TextInfoModel):
             self.flush_documents()
 
     def flush_documents(self):
-        self.db['html_text'].import_bulk(self.queue, on_duplicate='replace', halt_on_error=True)
+        self.db['html_text'].import_bulk_safe(self.queue, on_duplicate='replace')
         self.queue.clear()
 
     def update_code_points(self, lang_uid, unicode_points, force=False):


### PR DESCRIPTION
I uncovered some serious issues with import_bulk causing errors to be silently ignored.
I made a bug report on the python-arango repo and it's getting some attention.
My interim solution is to patch in a new method that is safer and reports all errors - at the moment it doesn't raise an exception because it would cause the load-data to fail.

Bewarned: it logs A LOT of errors, that are currently being silently ignored with data not being loaded into the database.