### PR TITLE
language dropdown ranges fixed

### DIFF
--- a/client/elements/menus/sc-language-menu.html
+++ b/client/elements/menus/sc-language-menu.html
@@ -270,7 +270,7 @@ Language-menu used in the suttaplex card for denoting which translations exist o
               }
               if (ids.includes('-')) {
                   const [id1, id2] = ids.split('-#');
-                  return `#${id1}–${id2}`;
+                  return `#${id1}--${id2}`;
               }
               return `#${ids}`;
           }

--- a/client/elements/suttaplex/sc-parallel-item.html
+++ b/client/elements/suttaplex/sc-parallel-item.html
@@ -338,7 +338,7 @@ It is in effect a miniature version of the suttaplex-card
               if (item.acronym) {
                 sc_acronym = item.acronym.split('//')[0];
                 const rootId = item.to.replace('~','');
-                const id_part = this._getParagraphRange(rootId);
+                const id_part = this._getParagraphRange(rootId).replace('-','–');;
                 return `${sc_acronym}${id_part}`;
               } else {
                 sc_acronym = this._transformId(item.to, item.uid, expansionData, 0);


### PR DESCRIPTION
An accidental en-dash had crept into the language menu so now removed and replaced by -- again.