### PR TITLE
[SUCE-558] labels not showing when infomode is off

### DIFF
--- a/client/elements/text/sc-segmented-text.html
+++ b/client/elements/text/sc-segmented-text.html
@@ -544,8 +544,8 @@
               }
               setTimeout(() => {
                   item.innerHTML = `
-                                <div class="image-link" title="${paragraph ? paragraph.description : ''}">
-                                    <span class="${prefix}">${displayText}</span>
+                                <div class="image-link" >
+                                    <span title="${paragraph ? paragraph.description : ''}" class="${prefix}">${displayText}</span>
                                     <iron-icon title="${this.localize('viewImage')}" class="image-book-link" icon="sc-svg-icons:book">
                                     </iron-icon>
                                 </div>

--- a/client/elements/text/sc-segmented-text.html
+++ b/client/elements/text/sc-segmented-text.html
@@ -485,7 +485,7 @@
                   newSegment.classList.add('original-text');
                   newSegment.innerHTML = content + ' ';
                   this._setScriptISOCode(newSegment, this.rootLang);
-                  segment.parentNode.insertBefore(newSegment, segment.nextSibling);
+                  if (segment) segment.parentNode.insertBefore(newSegment, segment.nextSibling);
               }
           }
 

--- a/client/styles/sc-text-paragraph-num-styles.html
+++ b/client/styles/sc-text-paragraph-num-styles.html
@@ -2,437 +2,441 @@
   <template>
     <style>
       /*a.bl:before {content:"bl "}*/
-      .adh-v:before {
+      .textual-info-paragraph.adh-v:before {
         content: "Adhik-v "
       }
 
-      .apz:before {
+      .textual-info-paragraph.apz:before {
         content: "APZ "
       }
 
-      .ba:before {
+      .textual-info-paragraph.ba:before {
         content: "BA "
       }
 
-      .bd:before {
+      .textual-info-paragraph.bd:before {
         content: "BD "
       }
 
-      .bhaisv:before {
+      .textual-info-paragraph.bhaisv:before {
         content: "Bhais-v "
       }
 
-      .bi:before {
+      .textual-info-paragraph.bi:before {
         content: "BI "
       }
 
-      .bjt:before {
+      .textual-info-paragraph.bjt:before {
         content: "BJT "
       }
 
-      .bm:before {
+      .textual-info-paragraph.bm:before {
         content: "BM "
       }
 
-      .bn:before {
+      .textual-info-paragraph.bn:before {
         content: "BN "
       }
 
-      .bps:before {
+      .textual-info-paragraph.bps:before {
         content: "BPS "
       }
 
-      .bv:before {
+      .textual-info-paragraph.bv:before {
         content: "BV "
       }
 
-      .bjt:before {
+      .textual-info-paragraph.bjt:before {
         content: "BJT "
       }
 
-      .cps:before {
+      .textual-info-paragraph.cps:before {
         content: "Cps "
       }
 
-      .d-vp:before {
+      .textual-info-paragraph.d-vp:before {
         content: "D vp "
       }
 
-      .divy:before {
+      .textual-info-paragraph.divy:before {
         content: "Divy "
       }
 
-      .dkd:before {
+      .textual-info-paragraph.dkd:before {
         content: "DkD "
       }
 
-      .dkm:before {
+      .textual-info-paragraph.dkm:before {
         content: "DkM "
       }
 
-      .eno89:before {
+      .textual-info-paragraph.eno89:before {
         content: "Eno "
       }
 
-      .es:before {
+      .textual-info-paragraph.es:before {
         content: "ES "
       }
 
-      .fa:before {
+      .textual-info-paragraph.fa:before {
         content: "Fa "
       }
 
-      .fuk03:before {
+      .textual-info-paragraph.fuk03:before {
         content: "Fuk "
       }
 
-      .fol:before {
+      .textual-info-paragraph.fol:before {
         content: "Fol "
       }
 
-      .gn:before {
+      .textual-info-paragraph.gn:before {
         content: "Verse "
       }
 
-      .hh:before {
+      .textual-info-paragraph.hh:before {
         content: "HH "
       }
 
       /*a.gatn:before {content:" "}*/
-      .ia:before {
+      .textual-info-paragraph.ia:before {
         content: "IA "
       }
 
-      .flw:before {
+      .textual-info-paragraph.flw:before {
         content: "FLW "
       }
 
-      .gbm:before {
+      .textual-info-paragraph.gbm:before {
         content: "GBM "
       }
 
-      .gno78:before {
+      .textual-info-paragraph.gno78:before {
         content: "Gno "
       }
 
-      .har04:before {
+      .textual-info-paragraph.har04:before {
         content: "Har "
       }
 
-      .hoe16:before {
+      .textual-info-paragraph.hoe16:before {
         content: "Hoe "
       }
 
-      .hos89a:before, .hos89b:before, .hos91:before {
+      .textual-info-paragraph.hos89a:before, .textual-info-paragraph.hos89b:before, .textual-info-paragraph.hos91:before {
         content: "Hos "
       }
 
-      .hs:before {
+      .textual-info-paragraph.hs:before {
         content: "Hs "
       }
 
-      .jb:before {
+      .textual-info-paragraph.jb:before {
         content: "JB "
       }
 
-      .jd:before {
+      .textual-info-paragraph.jd:before {
         content: "JD "
       }
 
-      .jsk:before {
+      .textual-info-paragraph.jsk:before {
         content: "JSK "
       }
 
-      .lh:before {
+      .textual-info-paragraph.lh:before {
         content: "LH "
       }
 
-      .kat:before {
+      .textual-info-paragraph.kat:before {
         content: "Kathina-v "
       }
 
-      .kel:before {
+      .textual-info-paragraph.kel:before {
         content: "Kel "
       }
 
-      .kl:before {
+      .textual-info-paragraph.kl:before {
         content: "KL "
       }
 
-      .ks:before {
+      .textual-info-paragraph.ks:before {
         content: "KS "
       }
 
-      .mat85:before, .mat88:before, .mat96:before {
+      .textual-info-paragraph.mat85:before, .textual-info-paragraph.mat88:before, .textual-info-paragraph.mat96:before {
         content: "Mat "
       }
 
-      .mc:before {
+      .textual-info-paragraph.mc:before {
         content: "MC "
       }
 
-      .mkv:before {
+      .textual-info-paragraph.mkv:before {
         content: "Mkv "
       }
 
-      .mit57:before {
+      .textual-info-paragraph.mit57:before {
         content: "Mit "
       }
 
-      .ms:before {
+      .textual-info-paragraph.ms:before {
         content: "MS "
       }
 
-      .msdiv:before {
+      .textual-info-paragraph.msdiv:before {
         content: "Msdiv "
       }
 
-      .msdiv-si:before {
+      .textual-info-paragraph.msdiv-si:before {
         content: "Msdiv "
       }
 
-      .msvi:before {
+      .textual-info-paragraph.msvi:before {
         content: "Msv i "
       }
 
-      .msvii:before {
+      .textual-info-paragraph.msvii:before {
         content: "Msv ii "
       }
 
-      .msviii:before {
+      .textual-info-paragraph.msviii:before {
         content: "Msv iii "
       }
 
-      .msviv:before {
+      .textual-info-paragraph.msviv:before {
         content: "Msv iv "
       }
 
-      .msvwi:before {
+      .textual-info-paragraph.msvwi:before {
         content: "Msv Wi "
       }
 
-      .mt:before {
+      .textual-info-paragraph.mt:before {
         content: "MT "
       }
 
-      .nm:before {
+      .textual-info-paragraph.nm:before {
         content: "NM "
       }
 
-      .np:before {
+      .textual-info-paragraph.np:before {
         content: "NP "
       }
 
-      .nst:before {
+      .textual-info-paragraph.nst:before {
         content: "NST "
       }
 
-      .of:before {
+      .textual-info-paragraph.of:before {
         content: "OF "
       }
 
-      .pand-v:before {
+      .textual-info-paragraph.pand-v:before {
         content: "Pand-v "
       }
 
-      .pl:before {
+      .textual-info-paragraph.pl:before {
         content: "PL "
       }
 
-      .pos-v:before {
+      .textual-info-paragraph.pos-v:before {
         content: "Pos-v "
       }
 
-      .prava-v:before {
+      .textual-info-paragraph.prava-v:before {
         content: "Prava-v "
       }
 
-      .pravr-v-i:before {
+      .textual-info-paragraph.pravr-v-i:before {
         content: "Pravr-v i "
       }
 
-      .pravr-v-ii:before {
+      .textual-info-paragraph.pravr-v-ii:before {
         content: "Pravr-v ii "
       }
 
-      .pravr-v-iii:before {
+      .textual-info-paragraph.pravr-v-iii:before {
         content: "Pravr-v iii "
       }
 
-      .pravr-v-iv:before {
+      .textual-info-paragraph.pravr-v-iv:before {
         content: "Pravr-v iv "
       }
 
-      .pts:before {
+      .textual-info-paragraph .pts:before {
         content: "PTS "
       }
 
-      .pts1ed:before {
+      .textual-info-paragraph .pts1ed:before {
         content: "PTS \(1st ed.) "
       }
 
-      .pts2ed:before {
+      .textual-info-paragraph .pts2ed:before {
         content: "PTS \(2nd ed.) "
       }
 
-      .pts-vp-pli:before {
+      .textual-info-paragraph .pts-vp-pli:before {
         content: "PTS vp pli ";
       }
 
-      .pts-vp-en:before {
+      .textual-info-paragraph.pts-vp-en:before {
         content: "PTS vp en ";
       }
 
-      .pts_pn:before {
+      .textual-info-paragraph.pts_pn:before {
         content: "PTS "
       }
 
-      .pts-s:before {
+      .textual-info-paragraph.pts-s:before {
         content: "PTS s ";
       }
 
-      .pts-cs:before {
+      .textual-info-paragraph.pts-cs:before {
         content: "PTS cs ";
       }
 
-      .pts-p-pli:before {
+      .textual-info-paragraph .pts-p-pli:before {
         content: "PTS p pli "
       }
 
-      .rs-vp:before {
+      .textual-info-paragraph.rs-vp:before {
         content: "RS vp "
       }
 
-      .san87:before, .san89:before {
+      .textual-info-paragraph.san87:before, .san89:before {
         content: "San "
       }
 
-      .sag:before {
+      .textual-info-paragraph.sag:before {
         content: "Sag "
       }
 
-      .say-v:before {
+      .textual-info-paragraph.say-v:before {
         content: "Say-v "
       }
 
-      .sb:before {
+      .textual-info-paragraph.sb:before {
         content: "SB "
       }
 
-      .sbh:before {
+      .textual-info-paragraph.sbh:before {
         content: "Sbh "
       }
 
-      .sbvi:before {
+      .textual-info-paragraph.sbvi:before {
         content: "Sbv i "
       }
 
-      .sbvii:before {
+      .textual-info-paragraph.sbvii:before {
         content: "Sbv ii "
       }
 
-      .sc:before {
+      .textual-info-paragraph.sc:before {
         content: "SC "
       }
 
-      .segmented-textual-info-paragraph.sc:before {
+      .textual-info-paragraph.segmented-textual-info-paragraph.sc:before {
         content: ""
       }
 
-      .sen:before {
+      .textual-info-paragraph.sen:before {
         content: "Sen "
       }
 
-      .sht:before {
+      .textual-info-paragraph.sht:before {
         content: "SHT "
       }
 
-      .svsv:before, .svv:before {
+      .textual-info-paragraph.svsv:before, .svv:before {
         content: "SNP "
       }
 
-      .ss:before {
+      .textual-info-paragraph.ss:before {
         content: "SS "
       }
 
-      .sv:before {
+      .textual-info-paragraph.sv:before {
         content: "SV "
       }
 
-      .t:before, .t-linehead:before {
+      .textual-info-paragraph.t:before, .t-linehead:before {
         content: "T "
       }
 
-      .tb:before {
+      .textual-info-paragraph.tb:before {
         content: "TB "
       }
 
-      .thv:before {
+      .textual-info-paragraph.thv:before {
         content: "THV "
       }
 
-      .tri62:before, .tri95:before {
+      .textual-info-paragraph.tri62:before, .tri95:before {
         content: "Tri "
       }
 
-      .us:before, .uvs:before {
+      .textual-info-paragraph.us:before, .uvs:before {
         content: "Ud "
       }
 
-      .ttc:before {
+      .textual-info-paragraph.ttc:before {
         content: "TTC "
       }
 
       /*a.tu:before {content:" "}*/
-      .uv:before {
+      .textual-info-paragraph.uv:before {
         content: "Uv "
       }
 
-      .vgns:before {
+      .textual-info-paragraph.vgns:before {
         content: "Vagga/verse "
       }
 
-      .vai58:before, .vai59:before, .vai61:before {
+      .textual-info-paragraph.vai58:before, .textual-info-paragraph.vai59:before, .textual-info-paragraph.vai61:before {
         content: "Vai "
       }
 
-      .var-v:before {
+      .textual-info-paragraph.var-v:before {
         content: "Var-v "
       }
 
-      .vns:before {
+      .textual-info-paragraph.vns:before {
         content: "SC verse "
       }
 
-      .vnp:before {
+      .textual-info-paragraph.vnp:before {
         content: "PTS verse "
       }
 
-      .vn:before {
+      .textual-info-paragraph.vn:before {
         content: "Vn "
       }
 
-      .wal48:before, .wal50:before, .wal52:before, .wal57c:before, .wal58:before, .wal59a:before, .wal60:before, .wal61:before, .wal68a:before, .wal70a:before, .wal70b:before, .wal76:before, .wal78:before, .wal80c:before {
+      .textual-info-paragraph.wal48:before, .textual-info-paragraph.wal50:before, .textual-info-paragraph.wal52:before,
+      .textual-info-paragraph.wal57c:before, .textual-info-paragraph.wal58:before, .textual-info-paragraph.wal59a:before,
+      .textual-info-paragraph.wal60:before, .textual-info-paragraph.wal61:before, .textual-info-paragraph.wal68a:before,
+      .textual-info-paragraph.wal70a:before, .textual-info-paragraph.wal70b:before, .textual-info-paragraph.wal76:before,
+      .textual-info-paragraph.wal78:before, .textual-info-paragraph.wal80c:before {
         content: "Wal "
       }
 
-      .wg:before {
+      .textual-info-paragraph.wg:before {
         content: "WG "
       }
 
-      .wp:before {
+      .textual-info-paragraph.wp:before {
         content: "WP "
       }
 
-      .wpv:before {
+      .textual-info-paragraph.wpv:before {
         content: "WP verse "
       }
 
-      .wr:before {
+      .textual-info-paragraph.wr:before {
         content: "WR "
       }
 
-      .yam72:before {
+      .textual-info-paragraph.yam72:before {
         content: "Yam "
       }
 

--- a/client/styles/sc-text-paragraph-num-styles.html
+++ b/client/styles/sc-text-paragraph-num-styles.html
@@ -267,15 +267,27 @@
         content: "PTS "
       }
 
+      .textual-info-paragraph.pts:before {
+        content: "PTS "
+      }
+
       .textual-info-paragraph .pts1ed:before {
         content: "PTS \(1st ed.) "
       }
 
-      .textual-info-paragraph .pts2ed:before {
+      .textual-info-paragraph.pts1ed:before {
+        content: "PTS \(1st ed.) "
+      }
+
+      .textual-info-paragraph.pts2ed:before {
         content: "PTS \(2nd ed.) "
       }
 
       .textual-info-paragraph .pts-vp-pli:before {
+        content: "PTS vp pli ";
+      }
+
+      .textual-info-paragraph.pts-vp-pli:before {
         content: "PTS vp pli ";
       }
 


### PR DESCRIPTION
This does not fix the issue with keeping an indented space in front of the paragraphs when you turn infomode off.
The change on sc-segmented-text is only because I got an error in the consule if there is no segment. You might want to change that.