### PR TITLE
[SUCE-572] static pages loading at top

### DIFF
--- a/client/elements/sc-donate-now-page.html
+++ b/client/elements/sc-donate-now-page.html
@@ -218,8 +218,7 @@
                 </template>
 
                 <paper-input label="{{localize('amount')}}" class="data-input amount-input" auto-validate
-                             pattern="^[+]?(\d+[.,]?\d{0,2})$" allowed-pattern="[0-9.,]"
-                             error-message="{{localize('invalidValue')}}" required maxlength=20></paper-input>
+                             pattern="^[+]?(\d+[.,]?\d{0,2})$" allowed-pattern="[0-9.,]" required maxlength=20></paper-input>
               </div>
 
               <p class="explanation">{{localize('chooseFrequency')}}</p>
@@ -493,10 +492,11 @@
           }
 
           resetForm() {
-              if (!this.$.donation_form) {
+              const donationForm = this.shadowRoot.querySelector('#donation_form');
+              if (!donationForm) {
                   return;
               }
-              this.$.donation_form.reset();
+              donationForm.reset();
               this.shadowRoot.querySelector('.amount-input').value = undefined;
               this.shadowRoot.querySelector('.one-time-donation').checked = true;
               this.shadowRoot.querySelector('.monthly-donation').checked = false;

--- a/client/elements/sc-page-static.html
+++ b/client/elements/sc-page-static.html
@@ -309,9 +309,7 @@
         hide-immediately>
       <home-page name="HOME"></home-page>
       <sc-donations-page name="DONATIONS"></sc-donations-page>
-      <template is="dom-if" name="DONATE-NOW" restamp>
-        <sc-donate-now-page id="donate"></sc-donate-now-page>
-      </template>
+      <sc-donate-now-page id="donate" name="DONATE-NOW"></sc-donate-now-page>
       <sc-downloads-page name="DOWNLOADS"></sc-downloads-page>
       <sc-offline-page name="OFFLINE"></sc-offline-page>
       <sc-numbering-page name="NUMBERING"></sc-numbering-page>
@@ -440,6 +438,7 @@
               this.shouldShowOrganizationalToolbar = ['ACKNOWLEDGMENTS', 'LICENSING', 'ABOUT'].includes(this.selectedPage);
               this.$.pages.selected = this.selectedPage;
               requestAnimationFrame(() => {this._selectNavbarLink()});
+              this.shadowRoot.querySelector('#donate').resetForm();
           }
 
           _createMetaData(pageSelection, localize) {


### PR DESCRIPTION
The dom-if on the donate-now page created the problem loading the static pages so this page has to reset manually. This is done now but it creates the problem that when you return to the page, it clears the values but some fields turn red. 
Not critical for launch. More important that the pages load at the top.